### PR TITLE
Updated dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
 var Readable = require('stream').Readable,
   geohash = require('ngeohash'),
   pip = require('point-in-polygon'),
-  turfExtent = require('turf-extent'),
-  turfFeaturecollection = require('turf-featurecollection'),
-  turfPolygon = require('turf-polygon'),
-  turfIntersect = require('turf-intersect'),
+  turfExtent = require('@turf/bbox').default,
+  turfHelpers = require('@turf/helpers'),
+  turfIntersect = require('@turf/intersect').default,
   turf = {
   	extent: turfExtent,
-  	featurecollection: turfFeaturecollection,
-  	polygon: turfPolygon,
+  	featurecollection: turfHelpers.featureCollection,
+  	polygon: turfHelpers.polygon,
   	intersect: turfIntersect
   },
   through2 = require('through2'),
   async = require('async'),
-  geojsonArea = require('geojson-area');
+  geojsonArea = require('@mapbox/geojson-area');
 
 /**
  * utilizing point-in-poly but providing support for geojson polys and holes.

--- a/package.json
+++ b/package.json
@@ -16,16 +16,15 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
+    "@mapbox/geojson-area": "^0.2.2",
+    "@turf/bbox": "^6.0.1",
+    "@turf/helpers": "^6.1.4",
+    "@turf/intersect": "^6.1.3",
     "async": "~0.2.10",
-    "geojson-area": "^0.1.0",
     "ngeohash": "0.6.0",
     "point-in-polygon": "0.0.0",
     "rc": "^1.2.8",
-    "through2": "~0.4.0",
-    "turf-extent": "1.0.4",
-    "turf-featurecollection": "1.0.1",
-    "turf-intersect": "1.0.2",
-    "turf-polygon": "1.0.3"
+    "through2": "~0.4.0"
   },
   "devDependencies": {
     "joe": "~1.4.0",


### PR DESCRIPTION
Hi Derrick,
first of all thanks for the package it really helped me!.

I've updated some dependencies. The motivation was that `geohash-poly` depends on [`turf-intersect`](https://www.npmjs.com/package/turf-intersect) which depends on [`jsts`](https://www.npmjs.com/package/jsts). When bundling `geohash-poly` with webpack in order to use it on a browser, the `jsts` package weighed too much. Luckily, new `@turf/intersect` doesn't depend on the `jsts` package, so I don't have the weight problem.

I have run tests and I got some failures, I was wondering if you can help me in order to debug them:

```
geohash-poly ➞  standard ➞  should geohash over split threshold shape. Precision 1.
geohash-poly ➞  standard ➞  should geohash over split threshold shape. Precision 1. ✘   
geohash-poly ➞  standard ✘  
geohash-poly ✘  

FAILURE: 184/185 tests ran successfully; 1 failed, 0 incomplete, 1 errors

Error #1:
geohash-poly ➞  standard ➞  should geohash over split threshold shape. Precision 1.
Error: poly1 and poly2 must be either polygons or multiPolygons
    at Object.intersect (/home/nickcis/repos/geohash-poly/node_modules/@turf/intersect/index.js:106:15)
    at preparePoly (/home/nickcis/repos/geohash-poly/index.js:140:33)
    at makeRow (/home/nickcis/repos/geohash-poly/index.js:160:5)
    at Hasher.getNextRow (/home/nickcis/repos/geohash-poly/index.js:223:5)
    at /home/nickcis/repos/geohash-poly/index.js:93:10
    at Object.async.whilst (/home/nickcis/repos/geohash-poly/node_modules/async/lib/async.js:619:13)
    at Hasher._read (/home/nickcis/repos/geohash-poly/index.js:90:9)
    at Hasher.Readable.read (_stream_readable.js:453:10)
    at resume_ (_stream_readable.js:929:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

Thanks in advance!